### PR TITLE
patch docstrip to remove error on lipsum build

### DIFF
--- a/mmtex/build
+++ b/mmtex/build
@@ -25,6 +25,8 @@ install() {
 patch -i kpathsea.patch
 # patch luaotfload
 patch -i luaotfload.patch
+# patch docstrip for lipsum
+patch -i docstrip.patch
 
 ## BUILD LUATEX BINARY
 

--- a/mmtex/files/docstrip.patch
+++ b/mmtex/files/docstrip.patch
@@ -1,0 +1,10 @@
+*** a/docstrip.dtx
+--- b/docstrip.dtx
+***************
+*** 4540,4543 ****
+--- 4540,4544 ----
+  %    \end{macrocode}
+  %
+  % \Finale
++ \catcode`~=13
+  \endinput

--- a/mmtex/sources
+++ b/mmtex/sources
@@ -18,6 +18,7 @@ meson.build # meson build file
 meson_options.txt # meson option file
 kpathsea.patch # patch for "extending" kpathsea
 luaotfload.patch # patch luaotfload font resolution
+docstrip.patch
 
 # Build dependencies
 http://mirrors.ctan.org/macros/latex/base/docstrip.dtx # docstrip (also l3docstrip)


### PR DESCRIPTION
the lipsum.ins script needs ~ as an active char. It can't be set on the command line, because docstrip is going haywire in this case. So I patched docstrip to set the character active in last line before `\endinput`. Not nice, but with that change MMTeX builds on my machine.