### PR TITLE
build deb archives for any architecture

### DIFF
--- a/mmtex/info
+++ b/mmtex/info
@@ -2,6 +2,6 @@ pkgver=$(git describe --tag | sed 's/^v//;s/-/./g')
 pkgdesc='A minimal modern (Lua)TeX distribution'
 pkgurl='https://github.com/vlasakm/mmtex'
 arch_arch=x86_64
-debian_arch=amd64
+debian_arch=`dpkg --print-architecture`
 arch_depends="zziplib libpng zlib otf-latin-modern otf-latinmodern-math harfbuzz"
 debian_depends="libzzip-0-13, libpng16-16, zlib1g, fonts-lmodern, libharfbuzz-bin"


### PR DESCRIPTION
Hi Michal,

yesterday I received a Rasperry Pi like board with a RISC-V chip that is running Debian. So I tried to build a version of MMTeX for this architecture and it worked like a charm. I had only change the `debian_arch` from `amd64` to `riscv64` in `mmtex/info`. With this pull-request the current architecture will be used instead. So it should also build on other architectures like ARM.

Kind regards,
Timm.